### PR TITLE
:construction_worker: Simplify passing coverage/tox envvars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,10 @@ jobs:
             -x tmp \
             -x .github \
             defaultapp tmp/
+
+      - name: Run basic checks
+        run: |
+          django-admin check
+          pytest
+        environment:
+          DJANGO_SETTINGS_MODULE=testapp.settings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,10 @@ jobs:
       - name: Run the startproject command
         run: |
           mkdir tmp
-          django-admin startproject --template . --extension=py-tpl,rst,gitignore,in,ini,cfg,toml,yml --name LICENSE -x tmp -x .github -x .github defaultapp tmp/
+          django-admin startproject \
+            --template . \
+            --extension=py-tpl,rst,gitignore,in,ini,cfg,toml,yml \
+            --name LICENSE \
+            -x tmp \
+            -x .github \
+            defaultapp tmp/

--- a/dotgithub/workflows/ci.yml
+++ b/dotgithub/workflows/ci.yml
@@ -27,13 +27,10 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: Install dependencies
-        run: pip install tox tox-gh-actions codecov
+        run: pip install tox tox-gh-actions
 
       - name: Run tests
-        run: |
-          export TOXENV=py${PYTHON_VERSION/./}-django${DJANGO/./}
-          tox
-          codecov -e TOXENV,DJANGO --file reports/coverage-${TOXENV}.xml
+        run: tox
         env:
           PYTHON_VERSION: ${{ matrix.python }}
           DJANGO: ${{ matrix.django }}
@@ -58,6 +55,8 @@ jobs:
         run: |
           pip install build --upgrade
           python -m build
+
+      # TODO: switch to verified publishers
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Since we use the codecov action to upload coverage reports, it already automatically merges the coverage data from the entire matrix. We do not need to manage envvars manually.